### PR TITLE
Human readable metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports.getMetrics = getMetrics;
 module.exports.prepareQueries = prepareQueries;
 module.exports.outputMetrics = outputMetrics;
 module.exports.elbMetrics = elbMetrics;
+module.exports.prepareResults = prepareResults;
 var queue = require('d3-queue').queue;
 var AWS = module.exports.AWS = require('aws-sdk');
 
@@ -43,7 +44,11 @@ function elbMetrics(startTime, endTime, region, elbname, callback) {
     };
 
     var queries = prepareQueries(parameters);
-    outputMetrics(queries, region, callback);
+    outputMetrics(queries, region, function (err, data) {
+        if (err) return callback(err);
+        var requestPercentages = prepareResults(startTime, endTime, data);
+        return callback(null, requestPercentages);
+    });
 }
 /**
  * Creates parameters for each cloudwatch query given the input from the user.
@@ -122,4 +127,46 @@ function getMetrics(params, region, callback) {
     var cloudwatch = new AWS.CloudWatch();
 
     cloudwatch.getMetricStatistics(params, callback);
+}
+
+function prepareResults(startTime, endTime, data) {
+    var diff = startTime - endTime;
+    var period = Math.abs(Math.floor(diff / 1000));
+    var total = [];
+    var sumLatency = 0;
+
+    for (var i = 0; i < data.length - 1; i++) {
+        total[i] = totalRequests(data[i]);
+    }
+    /* calculate percentage of 2xx, 3xx, 4xx, 5xx */
+
+    var requestPerSecond = Math.round((total[4] / period) * 100) / 100;
+    var percent2xx = Math.round(((total[0] / total[4]) * 100) * 100) / 100;
+    var percent3xx = Math.round(((total[1] / total[4]) * 100) * 100) / 100;
+    var percent4xx = Math.round(((total[2] / total[4]) * 100) * 100) / 100;
+    var percent5xx = Math.round(((total[3] / total[4]) * 100) * 100) / 100;
+
+    /* average latency */
+    data[5].Datapoints.forEach(function (i) {
+        sumLatency += i.Average;
+    });
+    var avgLatency = Math.round((sumLatency / data[5].Datapoints.length) * 100) / 100;
+
+    return {
+        'period': period + 's',
+        'requestPerSecond': requestPerSecond + '/s',
+        'percent2xx': percent2xx + ' %',
+        'percent3xx': percent3xx + ' %',
+        'percent4xx': percent4xx + ' %',
+        'percent5xx': percent5xx + ' %',
+        'avgLatency': avgLatency
+    };
+}
+
+function totalRequests(metric) {
+    var sum = 0;
+    metric.Datapoints.forEach(function (i) {
+        sum += i.Sum;
+    });
+    return sum;
 }

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function elbMetrics(startTime, endTime, region, elbname, callback) {
     outputMetrics(queries, region, function (err, data) {
         if (err) return callback(err);
         var requestPercentages = prepareResults(startTime, endTime, data);
-        return callback(null, requestPercentages);
+        callback(null, requestPercentages);
     });
 }
 /**

--- a/test/fixture/datapoints.json
+++ b/test/fixture/datapoints.json
@@ -4,17 +4,17 @@
         "Datapoints": [
             {
                 "Timestamp": "2016-08-20T12:02:00.000Z",
-                "Sum": 13,
+                "Sum": 1,
                 "Unit": "Count"
             },
             {
                 "Timestamp": "2016-08-20T12:39:00.000Z",
-                "Sum": 14,
+                "Sum": 3,
                 "Unit": "Count"
             },
             {
                 "Timestamp": "2016-08-20T11:40:00.000Z",
-                "Sum": 200,
+                "Sum": 20,
                 "Unit": "Count"
             }
         ]
@@ -24,17 +24,17 @@
         "Datapoints": [
             {
                 "Timestamp": "2016-08-20T12:02:00.000Z",
-                "Sum": 1,
+                "Sum": 4,
                 "Unit": "Count"
             },
             {
                 "Timestamp": "2016-08-20T12:59:00.000Z",
-                "Sum": 5,
+                "Sum": 4,
                 "Unit": "Count"
             },
             {
                 "Timestamp": "2016-08-20T12:39:00.000Z",
-                "Sum": 1,
+                "Sum": 4,
                 "Unit": "Count"
             }
         ]
@@ -49,12 +49,12 @@
             },
             {
                 "Timestamp": "2016-08-20T12:39:00.000Z",
-                "Sum": 21,
+                "Sum": 1,
                 "Unit": "Count"
             },
             {
                 "Timestamp": "2016-08-20T11:40:00.000Z",
-                "Sum": 11,
+                "Sum": 6,
                 "Unit": "Count"
             }
         ]
@@ -64,7 +64,7 @@
         "Datapoints": [
             {
                 "Timestamp": "2016-08-20T12:39:00.000Z",
-                "Sum": 1,
+                "Sum": 0,
                 "Unit": "Count"
             },
             {
@@ -79,17 +79,17 @@
         "Datapoints": [
             {
                 "Timestamp": "2016-08-20T12:02:00.000Z",
-                "Sum": 1,
+                "Sum": 20,
                 "Unit": "Count"
             },
             {
                 "Timestamp": "2016-08-20T12:39:00.000Z",
-                "Sum": 1,
+                "Sum": 20,
                 "Unit": "Count"
             },
             {
                 "Timestamp": "2016-08-20T11:40:00.000Z",
-                "Sum": 2,
+                "Sum": 8,
                 "Unit": "Count"
             }
         ]

--- a/test/fixture/datapoints.json
+++ b/test/fixture/datapoints.json
@@ -99,17 +99,17 @@
         "Datapoints": [
             {
                 "Timestamp": "2016-08-20T11:57:00.000Z",
-                "Average": 0.4,
+                "Average": 0.1,
                 "Unit": "Seconds"
             },
             {
                 "Timestamp": "2016-08-20T12:09:00.000Z",
-                "Average": 0.4,
+                "Average": 0.3,
                 "Unit": "Seconds"
             },
             {
                 "Timestamp": "2016-08-20T12:33:00.000Z",
-                "Average": 0.4,
+                "Average": 0.5,
                 "Unit": "Seconds"
             }
         ]

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,7 @@ var AWS = require('aws-sdk');
 var prepareQueries = metrics.prepareQueries;
 var outputMetrics = metrics.outputMetrics;
 var elbMetrics = metrics.elbMetrics;
+var prepareResults = metrics.prepareResults;
 var metricdatapoint = require('./fixture/datapoints.json');
 var parameters = require('./fixture/prepareQueries_fixtures.json');
 var originalCloudWatch = AWS.CloudWatch;
@@ -65,19 +66,29 @@ tape('mocking [CloudWatch]', function (assert) {
 
 tape('ELB metrics', function (assert) {
     var obj = {
-        startTime: 1471692377978,
-        endTime: 1471698014705,
+        startTime: 1473838245009,
+        endTime: 1473838232083,
         region: 'us-east-1',
         elbname: 'abc'
     };
     var datapoints = prepareQueries(obj);
+    var expectedPecentages = {period: '12s',
+    requestPerSecond: '4/s',
+    percent2xx: '50 %',
+    percent3xx: '25 %',
+    percent4xx: '22.92 %',
+    percent5xx: '2.08 %',
+    avgLatency: 0.4};
 
     outputMetrics(datapoints, datapoints[0].region, function (err, data) {
         assert.ifError(err);
         assert.deepEquals(data, metricdatapoint, 'ok results for getMetricStatistics equal');
+        var requestPercentages = prepareResults(obj.startTime, obj.endTime, data);
+        assert.deepEquals(requestPercentages, expectedPecentages, 'okay metric percentages equal');
         assert.end();
     });
 });
+
 
 tape('[CloudWatch] restore', function (assert) {
     AWS.CloudWatch = originalCloudWatch;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -78,7 +78,7 @@ tape('ELB metrics', function (assert) {
     percent3xx: '25 %',
     percent4xx: '22.92 %',
     percent5xx: '2.08 %',
-    avgLatency: 0.4};
+    avgLatency: 0.3};
 
     outputMetrics(datapoints, datapoints[0].region, function (err, data) {
         assert.ifError(err);


### PR DESCRIPTION
Gives percentage of request for a given `startTime`, `endTime`, `region`, `elbname` like so: 

elb-metrics --startTime 12345 --endTime 123456 --region 'us-east-1' --elbname 'abc'
```
{
    "period": "358s",
    "requestPerSecond": "3.22/s",
    "percent2xx": "98.87 %",
    "percent3xx": "0 %",
    "percent4xx": "1.13 %",
    "percent5xx": "0 %",
    "avgLatency": 0.29
}
```
_Note: The values provided are bogus values^_

cc @emilymcafee 💭 s ?