### PR TITLE
Rounding logic

### DIFF
--- a/test/fixture/prepareQueries_ALB.json
+++ b/test/fixture/prepareQueries_ALB.json
@@ -1,11 +1,11 @@
 [
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "HTTPCode_Target_2XX_Count",
             "Namespace": "AWS/ApplicationELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -20,11 +20,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "HTTPCode_Target_3XX_Count",
             "Namespace": "AWS/ApplicationELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -39,11 +39,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "HTTPCode_Target_4XX_Count",
             "Namespace": "AWS/ApplicationELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -58,11 +58,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "HTTPCode_Target_5XX_Count",
             "Namespace": "AWS/ApplicationELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -77,11 +77,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "RequestCount",
             "Namespace": "AWS/ApplicationELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -96,11 +96,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "TargetResponseTime",
             "Namespace": "AWS/ApplicationELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Average"
             ],

--- a/test/fixture/prepareQueries_ELB.json
+++ b/test/fixture/prepareQueries_ELB.json
@@ -1,11 +1,11 @@
 [
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "HTTPCode_Backend_2XX",
             "Namespace": "AWS/ELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -20,11 +20,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "HTTPCode_Backend_3XX",
             "Namespace": "AWS/ELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -39,11 +39,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "HTTPCode_Backend_4XX",
             "Namespace": "AWS/ELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -58,11 +58,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "HTTPCode_Backend_5XX",
             "Namespace": "AWS/ELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -77,11 +77,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "RequestCount",
             "Namespace": "AWS/ELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Sum"
             ],
@@ -96,11 +96,11 @@
     },
     {
         "parameter": {
-            "EndTime": "2016-08-19T13:44:36.790Z",
+            "EndTime": "2016-08-19T13:45:00.000Z",
             "MetricName": "Latency",
             "Namespace": "AWS/ELB",
             "Period": 60,
-            "StartTime": "2016-08-19T12:33:20.000Z",
+            "StartTime": "2016-08-19T12:33:00.000Z",
             "Statistics": [
                 "Average"
             ],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -136,7 +136,7 @@ tape('ELB metrics', function (assert) {
     percent3xx: '25 %',
     percent4xx: '22.92 %',
     percent5xx: '2.08 %',
-    avgLatency: 0.3};
+    avgLatency: '0.3 s'};
 
     outputMetrics(datapoints, datapoints[0].region, function (err, data) {
         assert.ifError(err);
@@ -147,6 +147,18 @@ tape('ELB metrics', function (assert) {
     });
 });
 
+tape('Rounding period for getMetricStatistics', function (assert) {
+    var obj = {
+        startTime: 1476087578216,
+        endTime: 1476087582537,
+        region: 'us-east-1',
+        elbname: 'abc'
+    };
+    var roundingTest = prepareQueries(obj, 1);
+    assert.deepEquals(roundingTest[0].parameter.StartTime, '2016-10-10T08:19:00.000Z', '2016-10-10T08:19:38.216Z rounded to 2016-10-10T08:19:00.000Z');
+    assert.deepEquals(roundingTest[0].parameter.EndTime, '2016-10-10T08:20:00.000Z', '2016-10-10T08:19:42.537Z rounded to 2016-10-10T08:20:00.000Z');
+    assert.end();
+});
 
 tape('[CloudWatch] restore', function (assert) {
     AWS.CloudWatch = originalCloudWatch;


### PR DESCRIPTION
Per voice w/ @emilymcafee, 
Rounding the start time down to the nearest minute and the end time up to the next minute makes the period `60s` which prevents `elb-metrics` from giving such results: 

```
{
    "period": "5s",
    "requestPerSecond": "0/s",
    "percent2xx": "NaN %",
    "percent3xx": "NaN %",
    "percent4xx": "NaN %",
    "percent5xx": "NaN %",
    "avgLatency": "NaNs"
}
```
for really short periods, like 5s ^
I've also added `s` as the unit for latency after looking at the datapoints for `Latency`/ `TargetResponseTime` where the unit is also in seconds. 

cc @emilymcafee, @yhahn looks fine ? ![image](https://cloud.githubusercontent.com/assets/10141319/19232420/4ee43a46-8efd-11e6-92b7-ae6fc7b93cca.png)

