### PR TITLE
Does away with StartTime and EndTime parameter error

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function getELBName(elbname, callback) {
 function prepareQueries(obj, elb) {
     var desiredMetricsParameters = [];
     var coeff = 1000 * 60 * 1;
-    var roundedEndTime = new Date(Math.round(obj.endTime / coeff) * coeff).getTime();
+    var roundedEndTime = new Date(Math.ceil(obj.endTime / coeff) * coeff).getTime();
     var roundedStartTime = new Date(Math.floor(obj.startTime / coeff) * coeff).getTime();
     if (elb) {
         var desiredELBMetrics = {


### PR DESCRIPTION
Switching `round` -> `ceiling` for the endTime because the error `StartTime and EndTime parameter error` shows up every time the period is a few seconds apart. 

cc @emilymcafee 