### PR TITLE
Better err handling mechanism

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ function getALBName(elbname, callback) {
     elbv2.describeLoadBalancers(parameter, function (err, data) {
         if (err) {
             if (err.code === 'LoadBalancerNotFound') return callback();
+            else return callback(err);
         } else {
             var arn = data.LoadBalancers[0].LoadBalancerArn;
             var albName = arn.match(/app.*/);
@@ -87,6 +88,7 @@ function getELBName(elbname, callback) {
     elb.describeLoadBalancers(parameter, function (err, data) {
         if (err) {
             if (err.code === 'LoadBalancerNotFound') return callback();
+            else return callback(err);
         }
         return callback(null, data.LoadBalancerDescriptions[0].LoadBalancerName);
     });


### PR DESCRIPTION
Right now when there is an error, and only if `LoadBalancerNotFound` is the `err.code` it calls the callback. There might be other errors to look out for which are hidden because of ^. 
This adds a better error handling mechanism. 

cc @yhahn, @emilymcafee 